### PR TITLE
Fix/iam condition

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -30,18 +30,29 @@ data "aws_iam_policy_document" "this" {
     sid = "NodeResourceDeletion"
     actions = [
       "ec2:TerminateInstances",
-      "ec2:DeleteLaunchTemplate",
     ]
 
     resources = ["*"]
 
     condition {
       test     = "StringEquals"
-      variable = "ec2:ResourceTag/karpenter.k8s.aws/cluster/${var.cluster_name}"
+      variable = "ec2:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
       values   = ["owned"]
     }
   }
+  statement {
+    sid = "KarpenterResourceDeletion"
+    actions = [
+      "ec2:DeleteLaunchTemplate",
+    ]
 
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:ResourceTag/karpenter.k8s.aws/cluster"
+      values   = [var.cluster_name]
+    }
+  }
   statement {
     sid       = "GetParameters"
     actions   = ["ssm:GetParameter"]

--- a/iam.tf
+++ b/iam.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "this" {
 
     condition {
       test     = "StringEquals"
-      variable = "ec2:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      variable = "ec2:ResourceTag/karpenter.k8s.aws/cluster/${var.cluster_name}"
       values   = ["owned"]
     }
   }


### PR DESCRIPTION
# Description

There was a change in tag naming scheme for karpenter resources which differs from official documentation (link bellow).
Thus we split delete permissions to two individual statements with different tag to correctly match owner of resource. 

https://karpenter.sh/v0.14.0/upgrade-guide/#upgrading-to-v0140

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

- Sample deployment was downscaled to 0 and back to 1 to trigger node deletion and creation. 
- Sample AWSNodeTemplate crd was deleted to test if karpenter delete old launch template correctly.

All went fine without errors