### PR TITLE
Feat/support new karpenter versions

### DIFF
--- a/.github/RELEASE_DRAFTER.yml
+++ b/.github/RELEASE_DRAFTER.yml
@@ -7,11 +7,25 @@ categories:
       - 'enhancement'
   - title: 'Bug Fixes'
     labels:
-      - 'fix'
-      - 'bugfix'
       - 'bug'
   - title: 'Documentation'
     label: 'documentation'
+  - title: 'CI'
+    label: 'ci'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'feature'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'ci'
+      - 'bug'
+      - 'documentation'
+  default: patch
 change-template: '- $TITLE, by @$AUTHOR (#$NUMBER)'
 template: |
   # What's changed

--- a/README.md
+++ b/README.md
@@ -111,12 +111,14 @@ No modules.
 | [helm_release.argo_application](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_manifest.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_iam_policy_document.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.this_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [utils_deep_merge_yaml.argo_helm_values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 | [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,11 @@ No modules.
 | [aws_sqs_queue_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
 | [helm_release.argo_application](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_job.helm_argo_application_wait](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/job) | resource |
 | [kubernetes_manifest.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubernetes_role.helm_argo_application_wait](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role) | resource |
+| [kubernetes_role_binding.helm_argo_application_wait](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/role_binding) | resource |
+| [kubernetes_service_account.helm_argo_application_wait](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_iam_policy_document.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -134,8 +138,10 @@ No modules.
 | <a name="input_argo_enabled"></a> [argo\_enabled](#input\_argo\_enabled) | If set to true, the module will be deployed as ArgoCD application, otherwise it will be deployed as a Helm release | `bool` | `false` | no |
 | <a name="input_argo_helm_enabled"></a> [argo\_helm\_enabled](#input\_argo\_helm\_enabled) | If set to true, the ArgoCD Application manifest will be deployed using Kubernetes provider as a Helm release. Otherwise it'll be deployed as a Kubernetes manifest. See Readme for more info | `bool` | `false` | no |
 | <a name="input_argo_helm_values"></a> [argo\_helm\_values](#input\_argo\_helm\_values) | Value overrides to use when deploying argo application object with helm | `string` | `""` | no |
+| <a name="input_argo_helm_wait_backoff_limit"></a> [argo\_helm\_wait\_backoff\_limit](#input\_argo\_helm\_wait\_backoff\_limit) | Backoff limit for ArgoCD Application Helm release wait job | `number` | `6` | no |
+| <a name="input_argo_helm_wait_timeout"></a> [argo\_helm\_wait\_timeout](#input\_argo\_helm\_wait\_timeout) | Timeout for ArgoCD Application Helm release wait job | `string` | `"10m"` | no |
 | <a name="input_argo_info"></a> [argo\_info](#input\_argo\_info) | ArgoCD info manifest parameter | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | <pre>[<br>  {<br>    "name": "terraform",<br>    "value": "true"<br>  }<br>]</pre> | no |
-| <a name="input_argo_kubernetes_manifest_computed_fields"></a> [argo\_kubernetes\_manifest\_computed\_fields](#input\_argo\_kubernetes\_manifest\_computed\_fields) | List of paths of fields to be handled as "computed". The user-configured value for the field will be overridden by any different value returned by the API after apply. | `list(string)` | <pre>[<br>  "metadata.labels",<br>  "metadata.annotations"<br>]</pre> | no |
+| <a name="input_argo_kubernetes_manifest_computed_fields"></a> [argo\_kubernetes\_manifest\_computed\_fields](#input\_argo\_kubernetes\_manifest\_computed\_fields) | List of paths of fields to be handled as "computed". The user-configured value for the field will be overridden by any different value returned by the API after apply. | `list(string)` | <pre>[<br>  "metadata.labels",<br>  "metadata.annotations",<br>  "metadata.finalizers"<br>]</pre> | no |
 | <a name="input_argo_kubernetes_manifest_field_manager_force_conflicts"></a> [argo\_kubernetes\_manifest\_field\_manager\_force\_conflicts](#input\_argo\_kubernetes\_manifest\_field\_manager\_force\_conflicts) | Forcibly override any field manager conflicts when applying the kubernetes manifest resource | `bool` | `false` | no |
 | <a name="input_argo_kubernetes_manifest_field_manager_name"></a> [argo\_kubernetes\_manifest\_field\_manager\_name](#input\_argo\_kubernetes\_manifest\_field\_manager\_name) | The name of the field manager to use when applying the kubernetes manifest resource. Defaults to Terraform | `string` | `"Terraform"` | no |
 | <a name="input_argo_kubernetes_manifest_wait_fields"></a> [argo\_kubernetes\_manifest\_wait\_fields](#input\_argo\_kubernetes\_manifest\_wait\_fields) | A map of fields and a corresponding regular expression with a pattern to wait for. The provider will wait until the field matches the regular expression. Use * for any value. | `map(string)` | `{}` | no |
@@ -193,7 +199,7 @@ No modules.
 | <a name="input_rbac_create"></a> [rbac\_create](#input\_rbac\_create) | Whether to create and use RBAC resources | `bool` | `true` | no |
 | <a name="input_rule_interruption_prefix"></a> [rule\_interruption\_prefix](#input\_rule\_interruption\_prefix) | Prefix used for all event bridge rules | `string` | `"Karpenter"` | no |
 | <a name="input_service_account_create"></a> [service\_account\_create](#input\_service\_account\_create) | Whether to create Service Account | `bool` | `true` | no |
-| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The k8s karpenter service account name | `string` | `"karpenter"` | no |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | The k8s <$addon-name> service account name | `string` | `"karpenter"` | no |
 | <a name="input_settings"></a> [settings](#input\_settings) | Additional helm sets which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/karpenter/karpenter | `map(any)` | `{}` | no |
 | <a name="input_values"></a> [values](#input\_values) | Additional yaml encoded values which will be passed to the Helm chart, see https://artifacthub.io/packages/helm/karpenter/karpenter | `string` | `""` | no |
 

--- a/README.md
+++ b/README.md
@@ -142,10 +142,11 @@ No modules.
 | <a name="input_argo_project"></a> [argo\_project](#input\_argo\_project) | ArgoCD Application project | `string` | `"default"` | no |
 | <a name="input_argo_spec"></a> [argo\_spec](#input\_argo\_spec) | ArgoCD Application spec configuration. Override or create additional spec parameters | `any` | `{}` | no |
 | <a name="input_argo_sync_policy"></a> [argo\_sync\_policy](#input\_argo\_sync\_policy) | ArgoCD syncPolicy manifest parameter | `any` | `{}` | no |
+| <a name="input_aws_partition"></a> [aws\_partition](#input\_aws\_partition) | AWS partition in which the resources are located. Avaliable values are `aws`, `aws-cn`, `aws-us-gov` | `string` | `"aws"` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_atomic"></a> [helm\_atomic](#input\_helm\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used | `bool` | `false` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"karpenter"` | no |
-| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"0.20.0"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"0.28.0"` | no |
 | <a name="input_helm_cleanup_on_fail"></a> [helm\_cleanup\_on\_fail](#input\_helm\_cleanup\_on\_fail) | Allow deletion of new resources created in this helm upgrade when upgrade fails | `bool` | `false` | no |
 | <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Create the namespace if it does not yet exist | `bool` | `true` | no |
 | <a name="input_helm_dependency_update"></a> [helm\_dependency\_update](#input\_helm\_dependency\_update) | Runs helm dependency update before installing the chart | `bool` | `false` | no |

--- a/argo-helm.tf
+++ b/argo-helm.tf
@@ -1,0 +1,150 @@
+locals {
+  helm_argo_application_enabled      = var.enabled && var.argo_enabled && var.argo_helm_enabled
+  helm_argo_application_wait_enabled = local.helm_argo_application_enabled && length(keys(var.argo_kubernetes_manifest_wait_fields)) > 0
+  helm_argo_application_values = [
+    one(data.utils_deep_merge_yaml.argo_helm_values[*].output),
+    var.argo_helm_values
+  ]
+}
+
+data "utils_deep_merge_yaml" "argo_helm_values" {
+  count = local.helm_argo_application_enabled ? 1 : 0
+
+  input = compact([
+    yamlencode({
+      "apiVersion" : var.argo_apiversion
+    }),
+    yamlencode({
+      "spec" : local.argo_application_values
+    }),
+    yamlencode({
+      "spec" : var.argo_spec
+    }),
+    yamlencode(
+      local.argo_application_metadata
+    )
+  ])
+}
+
+resource "helm_release" "argo_application" {
+  count = local.helm_argo_application_enabled ? 1 : 0
+
+  chart     = "${path.module}/helm/argocd-application"
+  name      = var.helm_release_name
+  namespace = var.argo_namespace
+
+  values = local.helm_argo_application_values
+}
+
+resource "kubernetes_role" "helm_argo_application_wait" {
+  count = local.helm_argo_application_wait_enabled ? 1 : 0
+
+  metadata {
+    name        = "${var.helm_release_name}-argo-application-wait"
+    namespace   = var.argo_namespace
+    labels      = local.argo_application_metadata.labels
+    annotations = local.argo_application_metadata.annotations
+  }
+
+  rule {
+    api_groups = ["argoproj.io"]
+    resources  = ["applications"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
+resource "kubernetes_role_binding" "helm_argo_application_wait" {
+  count = local.helm_argo_application_wait_enabled ? 1 : 0
+
+  metadata {
+    name        = "${var.helm_release_name}-argo-application-wait"
+    namespace   = var.argo_namespace
+    labels      = local.argo_application_metadata.labels
+    annotations = local.argo_application_metadata.annotations
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = one(kubernetes_role.helm_argo_application_wait[*].metadata[0].name)
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = one(kubernetes_service_account.helm_argo_application_wait[*].metadata[0].name)
+    namespace = one(kubernetes_service_account.helm_argo_application_wait[*].metadata[0].namespace)
+  }
+}
+
+resource "kubernetes_service_account" "helm_argo_application_wait" {
+  count = local.helm_argo_application_wait_enabled ? 1 : 0
+
+  metadata {
+    name        = "${var.helm_release_name}-argo-application-wait"
+    namespace   = var.argo_namespace
+    labels      = local.argo_application_metadata.labels
+    annotations = local.argo_application_metadata.annotations
+  }
+}
+
+resource "kubernetes_job" "helm_argo_application_wait" {
+  count = local.helm_argo_application_wait_enabled ? 1 : 0
+
+  metadata {
+    name        = "${var.helm_release_name}-argo-application-wait"
+    namespace   = var.argo_namespace
+    labels      = local.argo_application_metadata.labels
+    annotations = local.argo_application_metadata.annotations
+  }
+
+  spec {
+    template {
+      metadata {
+        name        = "${var.helm_release_name}-argo-application-wait"
+        labels      = local.argo_application_metadata.labels
+        annotations = local.argo_application_metadata.annotations
+      }
+
+      spec {
+        service_account_name = one(kubernetes_service_account.helm_argo_application_wait[*].metadata[0].name)
+
+        dynamic "container" {
+          for_each = var.argo_kubernetes_manifest_wait_fields
+
+          content {
+            name    = "${lower(replace(container.key, ".", "-"))}-${md5(jsonencode(local.helm_argo_application_values))}" # md5 suffix is a workaround for https://github.com/hashicorp/terraform-provider-kubernetes/issues/1325
+            image   = "bitnami/kubectl:latest"
+            command = ["/bin/bash", "-ecx"]
+            # Waits for ArgoCD Application to be "Healthy", see https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#wait
+            #   i.e. kubectl wait --for=jsonpath='{.status.sync.status}'=Healthy application.argoproj.io <$addon-name>
+            args = [
+              <<-EOT
+              kubectl wait \
+                --namespace ${var.argo_namespace} \
+                --for=jsonpath='{.${container.key}}'=${container.value} \
+                --timeout=${var.argo_helm_wait_timeout} \
+                application.argoproj.io ${var.helm_release_name}
+              EOT
+            ]
+          }
+        }
+
+        # ArgoCD Application status fields might not be available immediately after creation
+        restart_policy = "OnFailure"
+      }
+    }
+
+    backoff_limit = var.argo_helm_wait_backoff_limit
+  }
+
+  wait_for_completion = true
+
+  timeouts {
+    create = var.argo_helm_wait_timeout
+    update = var.argo_helm_wait_timeout
+  }
+
+  depends_on = [
+    helm_release.argo_application
+  ]
+}

--- a/argo.tf
+++ b/argo.tf
@@ -25,39 +25,6 @@ locals {
   }
 }
 
-data "utils_deep_merge_yaml" "argo_helm_values" {
-  count = var.enabled && var.argo_enabled && var.argo_helm_enabled ? 1 : 0
-  input = compact([
-    yamlencode({
-      "apiVersion" : var.argo_apiversion
-    }),
-    yamlencode({
-      "spec" : local.argo_application_values
-    }),
-    yamlencode({
-      "spec" : var.argo_spec
-    }),
-    yamlencode(
-      local.argo_application_metadata
-    )
-  ])
-}
-
-
-resource "helm_release" "argo_application" {
-  count = var.enabled && var.argo_enabled && var.argo_helm_enabled ? 1 : 0
-
-  chart     = "${path.module}/helm/argocd-application"
-  name      = var.helm_release_name
-  namespace = var.argo_namespace
-
-  values = [
-    data.utils_deep_merge_yaml.argo_helm_values[0].output,
-    var.argo_helm_values
-  ]
-}
-
-
 resource "kubernetes_manifest" "this" {
   count = var.enabled && var.argo_enabled && !var.argo_helm_enabled ? 1 : 0
   manifest = {

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -10,6 +10,7 @@ The code in this example shows how to use the module with basic configuration an
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.19.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.6.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.11.0 |
 
 ## Modules
 
@@ -21,7 +22,7 @@ The code in this example shows how to use the module with basic configuration an
 | <a name="module_addon_installation_helm"></a> [addon\_installation\_helm](#module\_addon\_installation\_helm) | ../../ | n/a |
 | <a name="module_eks_cluster"></a> [eks\_cluster](#module\_eks\_cluster) | cloudposse/eks-cluster/aws | 2.3.0 |
 | <a name="module_eks_node_group"></a> [eks\_node\_group](#module\_eks\_node\_group) | cloudposse/eks-node-group/aws | 2.4.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 3.14.2 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | 4.0.0 |
 
 ## Resources
 

--- a/examples/basic/base.tf
+++ b/examples/basic/base.tf
@@ -1,0 +1,33 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "4.0.0"
+
+  name               = "karpenter-vpc"
+  cidr               = "10.0.0.0/16"
+  azs                = ["eu-central-1a", "eu-central-1b"]
+  public_subnets     = ["10.0.101.0/24", "10.0.102.0/24"]
+  enable_nat_gateway = true
+}
+
+module "eks_cluster" {
+  source  = "cloudposse/eks-cluster/aws"
+  version = "2.3.0"
+
+  region     = "eu-central-1"
+  subnet_ids = module.vpc.public_subnets
+  vpc_id     = module.vpc.vpc_id
+  name       = "basic-example"
+}
+
+module "eks_node_group" {
+  source  = "cloudposse/eks-node-group/aws"
+  version = "2.4.0"
+
+  cluster_name   = module.eks_cluster.eks_cluster_id
+  instance_types = ["t3.medium"]
+  subnet_ids     = module.vpc.public_subnets
+  min_size       = 1
+  desired_size   = 1
+  max_size       = 2
+  depends_on     = [module.eks_cluster.kubernetes_config_map_id]
+}

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,37 +1,3 @@
-module "vpc" {
-  source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.2"
-
-  name               = "cluster-autoscaler-vpc"
-  cidr               = "10.0.0.0/16"
-  azs                = ["eu-central-1a", "eu-central-1b"]
-  public_subnets     = ["10.0.101.0/24", "10.0.102.0/24"]
-  enable_nat_gateway = true
-}
-
-module "eks_cluster" {
-  source  = "cloudposse/eks-cluster/aws"
-  version = "2.3.0"
-
-  region     = "eu-central-1"
-  subnet_ids = module.vpc.public_subnets
-  vpc_id     = module.vpc.vpc_id
-  name       = "basic-example"
-}
-
-module "eks_node_group" {
-  source  = "cloudposse/eks-node-group/aws"
-  version = "2.4.0"
-
-  cluster_name   = module.eks_cluster.eks_cluster_id
-  instance_types = ["t3.medium"]
-  subnet_ids     = module.vpc.public_subnets
-  min_size       = 1
-  desired_size   = 1
-  max_size       = 2
-  depends_on     = [module.eks_cluster.kubernetes_config_map_id]
-}
-
 resource "aws_iam_role" "this" {
   name               = "karpenter-node-role"
   assume_role_policy = data.aws_iam_policy_document.karpenter_node_assume_policy.json
@@ -77,6 +43,7 @@ module "addon_installation_helm" {
   })
 }
 
+# Please, see README.md and Argo Kubernetes deployment method for implications of using Kubernetes installation method
 module "addon_installation_argo_kubernetes" {
   source = "../../"
 

--- a/examples/basic/providers.tf
+++ b/examples/basic/providers.tf
@@ -10,6 +10,12 @@ data "aws_eks_cluster_auth" "this" {
   name = module.eks_cluster.eks_cluster_id
 }
 
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.this.endpoint
+  token                  = data.aws_eks_cluster_auth.this.token
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.this.certificate_authority[0].data)
+}
+
 provider "helm" {
   kubernetes {
     host                   = data.aws_eks_cluster.this.endpoint

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.19.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.11.0"
+    }
     helm = {
       source  = "hashicorp/helm"
       version = ">= 2.6.0"

--- a/values.tf
+++ b/values.tf
@@ -10,6 +10,8 @@ locals {
       }
     }
     "serviceAccount" : {
+      "create" : var.service_account_create
+      "name" : var.service_account_name
       "annotations" : {
         "eks.amazonaws.com/role-arn" : local.irsa_role_create ? aws_iam_role.this[0].arn : ""
       }

--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "0.20.0"
+  default     = "0.28.0"
   description = "Version of the Helm chart"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,13 @@ variable "karpenter_node_role_arns" {
   default     = ["*"]
   description = "List of roles arns which can be passed from karpenter service to newly created nodes"
 }
+
+variable "aws_partition" {
+  type        = string
+  default     = "aws"
+  description = "AWS partition in which the resources are located. Avaliable values are `aws`, `aws-cn`, `aws-us-gov`"
+}
+
 # ================ common variables (required) ================
 
 variable "helm_chart_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,7 @@ variable "helm_release_name" {
   default     = "karpenter"
   description = "Helm release name"
 }
+
 variable "helm_repo_url" {
   type        = string
   default     = "public.ecr.aws"
@@ -168,6 +169,18 @@ variable "argo_helm_enabled" {
   description = "If set to true, the ArgoCD Application manifest will be deployed using Kubernetes provider as a Helm release. Otherwise it'll be deployed as a Kubernetes manifest. See Readme for more info"
 }
 
+variable "argo_helm_wait_timeout" {
+  type        = string
+  default     = "10m"
+  description = "Timeout for ArgoCD Application Helm release wait job"
+}
+
+variable "argo_helm_wait_backoff_limit" {
+  type        = number
+  default     = 6
+  description = "Backoff limit for ArgoCD Application Helm release wait job"
+}
+
 variable "argo_destination_server" {
   type        = string
   default     = "https://kubernetes.default.svc"
@@ -230,7 +243,7 @@ variable "argo_helm_values" {
 
 variable "argo_kubernetes_manifest_computed_fields" {
   type        = list(string)
-  default     = ["metadata.labels", "metadata.annotations"]
+  default     = ["metadata.labels", "metadata.annotations", "metadata.finalizers"]
   description = "List of paths of fields to be handled as \"computed\". The user-configured value for the field will be overridden by any different value returned by the API after apply."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -100,6 +100,12 @@ variable "service_account_create" {
   description = "Whether to create Service Account"
 }
 
+variable "service_account_name" {
+  type        = string
+  default     = "karpenter"
+  description = "The k8s <$addon-name> service account name"
+}
+
 variable "irsa_role_create" {
   type        = bool
   default     = true
@@ -140,12 +146,6 @@ variable "irsa_tags" {
   type        = map(string)
   default     = {}
   description = "IRSA resources tags"
-}
-
-variable "service_account_name" {
-  type        = string
-  default     = "karpenter"
-  description = "The k8s karpenter service account name"
 }
 
 # ================ argo variables (required) ================


### PR DESCRIPTION
# Description
- Change the default karpenter chart version to the 0.28.0
- Add autodiscovery policy to allow the karpenter to resolve EKS cluster based on cluster_name

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
Fully tested
