### PR TITLE
Add ec2:CreateTags permission for spot-instances-request

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -74,6 +74,7 @@ data "aws_iam_policy_document" "this" {
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:fleet/*",
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:instance/*",
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:volume/*",
+      "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:spot-instances-request/*",
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:network-interface/*",
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:launch-template/*",
     ]


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

Fixes #7 

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
Several nodes was drained to force replacement and creation of new spot instance nodes. 


<!--
Please describe the tests that you ran to verify your changes.
-->
