### PR TITLE
feat: upgrade karpenter to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ No modules.
 | <a name="input_crds_argo_sync_policy"></a> [crds\_argo\_sync\_policy](#input\_crds\_argo\_sync\_policy) | ArgoCD syncPolicy manifest parameter | `any` | `{}` | no |
 | <a name="input_crds_helm_atomic"></a> [crds\_helm\_atomic](#input\_crds\_helm\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used | `bool` | `false` | no |
 | <a name="input_crds_helm_chart_name"></a> [crds\_helm\_chart\_name](#input\_crds\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"karpenter-crd"` | no |
-| <a name="input_crds_helm_chart_version"></a> [crds\_helm\_chart\_version](#input\_crds\_helm\_chart\_version) | Version of the Helm chart | `string` | `"0.36.2"` | no |
+| <a name="input_crds_helm_chart_version"></a> [crds\_helm\_chart\_version](#input\_crds\_helm\_chart\_version) | Version of the Helm chart | `string` | `"1.0.8"` | no |
 | <a name="input_crds_helm_cleanup_on_fail"></a> [crds\_helm\_cleanup\_on\_fail](#input\_crds\_helm\_cleanup\_on\_fail) | Allow deletion of new resources created in this helm upgrade when upgrade fails | `bool` | `false` | no |
 | <a name="input_crds_helm_dependency_update"></a> [crds\_helm\_dependency\_update](#input\_crds\_helm\_dependency\_update) | Runs helm dependency update before installing the chart | `bool` | `false` | no |
 | <a name="input_crds_helm_description"></a> [crds\_helm\_description](#input\_crds\_helm\_description) | Set helm release description attribute (visible in the history) | `string` | `""` | no |
@@ -198,7 +198,7 @@ No modules.
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Variable indicating whether deployment is enabled | `bool` | `true` | no |
 | <a name="input_helm_atomic"></a> [helm\_atomic](#input\_helm\_atomic) | If set, installation process purges chart on fail. The wait flag will be set automatically if atomic is used | `bool` | `false` | no |
 | <a name="input_helm_chart_name"></a> [helm\_chart\_name](#input\_helm\_chart\_name) | Helm chart name to be installed | `string` | `"karpenter"` | no |
-| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"0.36.2"` | no |
+| <a name="input_helm_chart_version"></a> [helm\_chart\_version](#input\_helm\_chart\_version) | Version of the Helm chart | `string` | `"1.0.8"` | no |
 | <a name="input_helm_cleanup_on_fail"></a> [helm\_cleanup\_on\_fail](#input\_helm\_cleanup\_on\_fail) | Allow deletion of new resources created in this helm upgrade when upgrade fails | `bool` | `false` | no |
 | <a name="input_helm_create_namespace"></a> [helm\_create\_namespace](#input\_helm\_create\_namespace) | Create the namespace if it does not yet exist | `bool` | `true` | no |
 | <a name="input_helm_dependency_update"></a> [helm\_dependency\_update](#input\_helm\_dependency\_update) | Runs helm dependency update before installing the chart | `bool` | `false` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -109,6 +109,15 @@ data "aws_iam_policy_document" "this" {
       values   = ["owned"]
     }
 
+    condition { # Karpenter v1 Migration: Include additional tag-scoping for the eks:eks-cluster-name tag - https://karpenter.sh/docs/reference/cloudformation/#allowscopedresourcetagging
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+
+      values = [
+        var.cluster_name
+      ]
+    }
+
     condition {
       test     = "StringEquals"
       variable = "ec2:CreateAction"
@@ -143,15 +152,6 @@ data "aws_iam_policy_document" "this" {
       test     = "StringLike"
       variable = "aws:ResourceTag/karpenter.sh/nodepool"
       values   = ["*"]
-    }
-
-    condition { # Karpenter v1 Migration: Include additional tag-scoping for the eks:eks-cluster-name tag - https://karpenter.sh/docs/reference/cloudformation/#allowscopedresourcetagging
-      test     = "StringEquals"
-      variable = "aws:RequestTag/eks:eks-cluster-name"
-
-      values = [
-        var.cluster_name
-      ]
     }
 
     condition { # Karpenter v1 Migration: Include additional tag-scoping for the eks:eks-cluster-name tag - https://karpenter.sh/docs/reference/cloudformation/#allowscopedresourcetagging

--- a/iam.tf
+++ b/iam.tf
@@ -145,11 +145,29 @@ data "aws_iam_policy_document" "this" {
       values   = ["*"]
     }
 
+    condition { # Karpenter v1 Migration: Include additional tag-scoping for the eks:eks-cluster-name tag - https://karpenter.sh/docs/reference/cloudformation/#allowscopedresourcetagging
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+
+      values = [
+        var.cluster_name
+      ]
+    }
+
+    condition { # Karpenter v1 Migration: Include additional tag-scoping for the eks:eks-cluster-name tag - https://karpenter.sh/docs/reference/cloudformation/#allowscopedresourcetagging
+      test     = "StringEqualsIfExists"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values = [
+        var.cluster_name
+      ]
+    }
+
     condition {
       test     = "ForAllValues:StringEquals"
       variable = "aws:TagKeys"
 
       values = [
+        "eks:eks-cluster-name",
         "karpenter.sh/nodeclaim",
         "Name",
       ]

--- a/variables-crds.tf
+++ b/variables-crds.tf
@@ -8,7 +8,7 @@ variable "crds_helm_chart_name" {
 
 variable "crds_helm_chart_version" {
   type        = string
-  default     = "0.36.2"
+  default     = "1.0.8"
   description = "Version of the Helm chart"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "helm_chart_name" {
 
 variable "helm_chart_version" {
   type        = string
-  default     = "0.36.2"
+  default     = "1.0.8"
   description = "Version of the Helm chart"
 }
 


### PR DESCRIPTION
# Description
This PR adjust public karpenter to support migration to v1. Main change in this module was in `iam.tf` section. IAM Role used by Karpenter controller needs its policy updated with new conditions around ec2:CreateTags action. Step `8` in Karpenter migration guide. https://karpenter.sh/v1.0/upgrading/v1-migration/

## Type of change

- [x] A new feature (PR prefix `feat`)

## How Has This Been Tested?
Tested within lara-sandbox-ec1-3. Karpenter upgraded to v1. Tested scaling of nodes.
<!--
Please describe the tests that you ran to verify your changes.
-->
