### PR TITLE
refactor(karpenter): fix policies to match with latest docs

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -338,6 +338,12 @@ data "aws_iam_policy_document" "this" {
     }
 
     condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/topology.kubernetes.io/region"
+      values   = [data.aws_region.this[0].name]
+    }
+
+    condition {
       test     = "StringLike"
       variable = "aws:ResourceTag/karpenter.k8s.aws/ec2nodeclass"
       values   = ["*"]

--- a/iam.tf
+++ b/iam.tf
@@ -15,7 +15,7 @@ data "aws_iam_policy_document" "this" {
   #checkov:skip=CKV_AWS_356: Describe need to be allowed on all resources
   count = local.irsa_role_create && var.irsa_policy_enabled && !var.irsa_assume_role_enabled ? 1 : 0
 
-  # Aligned with https://github.com/aws/karpenter-provider-aws/blob/v0.36.1/website/content/en/preview/getting-started/getting-started-with-karpenter/cloudformation.yaml
+  # Aligned with https://github.com/aws/karpenter-provider-aws/blob/main/website/content/en/v1.4/getting-started/getting-started-with-karpenter/cloudformation.yaml
   statement {
     sid    = "AllowScopedEC2InstanceAccessActions"
     effect = "Allow"


### PR DESCRIPTION
# Description

Follow the karpenter [guide](https://karpenter.sh/docs/reference/cloudformation/#karpentercontrollerpolicy) and fix differences

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [X] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?
- Deployed in sandbox1 via custom local module
- Verified karpenter logs and behaviour
