### PR TITLE
fix(iam): split IAM policies due to size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,27 @@ See [basic example](examples/basic) for further information.
 |------|------|
 | [aws_cloudwatch_event_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_iam_policy.eks_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.iam_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.interruption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.node_lifecycle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.resource_discovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.eks_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.iam_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.interruption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.node_lifecycle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.resource_discovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_sqs_queue.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue) | resource |
 | [aws_sqs_queue_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue_policy) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_iam_policy_document.eks_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.iam_integration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.interruption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.node_lifecycle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+| [aws_iam_policy_document.resource_discovery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [utils_deep_merge_yaml.crds_values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |
 | [utils_deep_merge_yaml.values](https://registry.terraform.io/providers/cloudposse/utils/latest/docs/data-sources/deep_merge_yaml) | data source |

--- a/iam.tf
+++ b/iam.tf
@@ -11,7 +11,7 @@ locals {
 #  Policies are split into multiple policies based on https://karpenter.sh/docs/reference/cloudformation/#controller-authorization due to managed policy length limit of 6,144 characters.
 data "aws_iam_policy_document" "node_lifecycle" {
   #checkov:skip=CKV_AWS_111: In the future, we may further lock down ec2:RunInstances by using tags in related resources.
-  count = var.enabled && var.irsa_policy == null && local.irsa_policy_enabled ? 1 : 0
+  count = local.irsa_policy_enabled ? 1 : 0
 
   statement {
     sid    = "AllowScopedEC2InstanceAccessActions"

--- a/iam.tf
+++ b/iam.tf
@@ -1,21 +1,18 @@
 locals {
-  irsa_policy_enabled = var.irsa_policy_enabled != null ? var.irsa_policy_enabled : coalesce(var.irsa_assume_role_enabled, false) == false
+  irsa_policy_enabled = (
+    var.enabled                                                                                                             // The addon must be enabled
+    && (var.irsa_policy_enabled != null ? var.irsa_policy_enabled : coalesce(var.irsa_assume_role_enabled, false) == false) // IRSA policy is only enabled by default if IRSA is enabled but assume role is not enabled, otherwise we assume the user will provide the necessary permissions in the custom policy
+    && var.irsa_policy == null                                                                                              // No custom policy provided
+    && module.addon-irsa[local.addon.name].irsa_role_enabled                                                                // IRSA role must be enabled for the policy to be relevant
+  )
 }
 
-data "aws_region" "this" {
-  count = var.enabled ? 1 : 0
-}
-
-data "aws_caller_identity" "this" {
-  count = var.enabled ? 1 : 0
-}
-
-data "aws_iam_policy_document" "this" {
+# IAM policies are aligned with https://github.com/aws/karpenter-provider-aws/blob/main/website/content/en/v1.8/getting-started/getting-started-with-karpenter/cloudformation.yaml.
+#  Policies are split into multiple policies based on https://karpenter.sh/docs/reference/cloudformation/#controller-authorization due to managed policy length limit of 6,144 characters.
+data "aws_iam_policy_document" "node_lifecycle" {
   #checkov:skip=CKV_AWS_111: In the future, we may further lock down ec2:RunInstances by using tags in related resources.
-  #checkov:skip=CKV_AWS_356: Describe need to be allowed on all resources
   count = var.enabled && var.irsa_policy == null && local.irsa_policy_enabled ? 1 : 0
 
-  # Aligned with https://github.com/aws/karpenter-provider-aws/blob/main/website/content/en/v1.7/getting-started/getting-started-with-karpenter/cloudformation.yaml
   statement {
     sid    = "AllowScopedEC2InstanceAccessActions"
     effect = "Allow"
@@ -25,6 +22,7 @@ data "aws_iam_policy_document" "this" {
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}::snapshot/*",
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:security-group/*",
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:subnet/*",
+      "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:capacity-reservation/*",
     ]
 
     actions = [
@@ -67,6 +65,7 @@ data "aws_iam_policy_document" "this" {
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:network-interface/*",
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:launch-template/*",
       "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:spot-instances-request/*",
+      "arn:${var.aws_partition}:ec2:${data.aws_region.this[0].name}:*:capacity-reservation/*",
     ]
 
     actions = [
@@ -162,7 +161,8 @@ data "aws_iam_policy_document" "this" {
       values   = ["*"]
     }
 
-    condition { # Karpenter v1 Migration: Include additional tag-scoping for the eks:eks-cluster-name tag - https://karpenter.sh/docs/reference/cloudformation/#allowscopedresourcetagging
+    # Karpenter v1 Migration: Include additional tag-scoping for the eks:eks-cluster-name tag - https://karpenter.sh/docs/reference/cloudformation/#allowscopedresourcetagging
+    condition {
       test     = "StringEqualsIfExists"
       variable = "aws:RequestTag/eks:eks-cluster-name"
       values = [
@@ -208,56 +208,10 @@ data "aws_iam_policy_document" "this" {
       values   = ["*"]
     }
   }
+}
 
-  statement {
-    sid       = "AllowRegionalReadActions"
-    effect    = "Allow"
-    resources = ["*"]
-
-    actions = [
-      "ec2:DescribeAvailabilityZones", # Missing in the example but its there in description: https://karpenter.sh/docs/reference/cloudformation/#allowregionalreadactions
-      "ec2:DescribeImages",
-      "ec2:DescribeInstances",
-      "ec2:DescribeInstanceTypeOfferings",
-      "ec2:DescribeInstanceTypes",
-      "ec2:DescribeLaunchTemplates",
-      "ec2:DescribeSecurityGroups",
-      "ec2:DescribeSpotPriceHistory",
-      "ec2:DescribeSubnets",
-    ]
-
-    condition {
-      test     = "StringEquals"
-      variable = "aws:RequestedRegion"
-      values   = [data.aws_region.this[0].name]
-    }
-  }
-
-  statement {
-    sid       = "AllowSSMReadActions"
-    effect    = "Allow"
-    resources = ["arn:${var.aws_partition}:ssm:${data.aws_region.this[0].name}::parameter/aws/service/*"]
-    actions   = ["ssm:GetParameter"]
-  }
-
-  statement {
-    sid       = "AllowPricingReadActions"
-    effect    = "Allow"
-    resources = ["*"]
-    actions   = ["pricing:GetProducts"]
-  }
-
-  statement {
-    sid       = "AllowInterruptionQueueActions"
-    effect    = "Allow"
-    resources = [aws_sqs_queue.this[0].arn]
-
-    actions = [
-      "sqs:DeleteMessage",
-      "sqs:GetQueueUrl",
-      "sqs:ReceiveMessage",
-    ]
-  }
+data "aws_iam_policy_document" "iam_integration" {
+  count = local.irsa_policy_enabled ? 1 : 0
 
   statement {
     sid       = "AllowPassingInstanceRole"
@@ -385,13 +339,78 @@ data "aws_iam_policy_document" "this" {
       values   = ["*"]
     }
   }
+}
+
+data "aws_iam_policy_document" "eks_integration" {
+  count = local.irsa_policy_enabled ? 1 : 0
 
   statement {
-    sid       = "AllowInstanceProfileReadActions"
+    sid       = "AllowAPIServerEndpointDiscovery"
     effect    = "Allow"
-    resources = ["arn:${var.aws_partition}:iam::${data.aws_caller_identity.this[0].account_id}:instance-profile/*"]
-    actions   = ["iam:GetInstanceProfile"]
+    resources = ["arn:${var.aws_partition}:eks:${data.aws_region.this[0].name}:${data.aws_caller_identity.this[0].account_id}:cluster/${var.cluster_name}"]
+    actions   = ["eks:DescribeCluster"]
   }
+}
+
+data "aws_iam_policy_document" "interruption" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  statement {
+    sid       = "AllowInterruptionQueueActions"
+    effect    = "Allow"
+    resources = [aws_sqs_queue.this[0].arn]
+
+    actions = [
+      "sqs:DeleteMessage",
+      "sqs:GetQueueUrl",
+      "sqs:ReceiveMessage",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "resource_discovery" {
+  #checkov:skip=CKV_AWS_356: Describe need to be allowed on all resources
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  statement {
+    sid       = "AllowRegionalReadActions"
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "ec2:DescribeCapacityReservations",
+      "ec2:DescribeAvailabilityZones", # Missing in the example but its there in description: https://karpenter.sh/docs/reference/cloudformation/#allowregionalreadactions
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceTypeOfferings",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeLaunchTemplates",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSpotPriceHistory",
+      "ec2:DescribeSubnets",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values   = [data.aws_region.this[0].name]
+    }
+  }
+
+  statement {
+    sid       = "AllowSSMReadActions"
+    effect    = "Allow"
+    resources = ["arn:${var.aws_partition}:ssm:${data.aws_region.this[0].name}::parameter/aws/service/*"]
+    actions   = ["ssm:GetParameter"]
+  }
+
+  statement {
+    sid       = "AllowPricingReadActions"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["pricing:GetProducts"]
+  }
+
   # Required IAM permission for Karpenter v1.7.0 and later to manage EC2 instance profiles:
   # See: https://karpenter.sh/docs/upgrading/upgrade-guide/#upgrading-to-170
   statement {
@@ -402,9 +421,99 @@ data "aws_iam_policy_document" "this" {
   }
 
   statement {
-    sid       = "AllowAPIServerEndpointDiscovery"
+    sid       = "AllowInstanceProfileReadActions"
     effect    = "Allow"
-    resources = ["arn:${var.aws_partition}:eks:${data.aws_region.this[0].name}:${data.aws_caller_identity.this[0].account_id}:cluster/${var.cluster_name}"]
-    actions   = ["eks:DescribeCluster"]
+    resources = ["arn:${var.aws_partition}:iam::${data.aws_caller_identity.this[0].account_id}:instance-profile/*"]
+    actions   = ["iam:GetInstanceProfile"]
   }
+}
+
+resource "aws_iam_policy" "node_lifecycle" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  description = "Node lifecycle policy for ${module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name} addon"
+  name        = "${module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name}-node-lifecycle" # tflint-ignore: aws_iam_policy_invalid_name
+  path        = "/"
+  policy      = data.aws_iam_policy_document.node_lifecycle[0].json
+
+  tags = var.irsa_tags
+}
+
+resource "aws_iam_role_policy_attachment" "node_lifecycle" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  role       = module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name
+  policy_arn = aws_iam_policy.node_lifecycle[0].arn
+}
+
+resource "aws_iam_policy" "iam_integration" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  description = "IAM integration policy for ${module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name} addon"
+  name        = "${module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name}-iam-integration" # tflint-ignore: aws_iam_policy_invalid_name
+  path        = "/"
+  policy      = data.aws_iam_policy_document.iam_integration[0].json
+
+  tags = var.irsa_tags
+}
+
+resource "aws_iam_role_policy_attachment" "iam_integration" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  role       = module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name
+  policy_arn = aws_iam_policy.iam_integration[0].arn
+}
+
+resource "aws_iam_policy" "eks_integration" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  description = "EKS integration policy for ${module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name} addon"
+  name        = "${module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name}-eks-integration" # tflint-ignore: aws_iam_policy_invalid_name
+  path        = "/"
+  policy      = data.aws_iam_policy_document.eks_integration[0].json
+
+  tags = var.irsa_tags
+}
+
+resource "aws_iam_role_policy_attachment" "eks_integration" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  role       = module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name
+  policy_arn = aws_iam_policy.eks_integration[0].arn
+}
+
+resource "aws_iam_policy" "interruption" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  description = "Interruption handling policy for ${module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name} addon"
+  name        = "${module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name}-interruption" # tflint-ignore: aws_iam_policy_invalid_name
+  path        = "/"
+  policy      = data.aws_iam_policy_document.interruption[0].json
+
+  tags = var.irsa_tags
+}
+
+resource "aws_iam_role_policy_attachment" "interruption" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  role       = module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name
+  policy_arn = aws_iam_policy.interruption[0].arn
+}
+
+resource "aws_iam_policy" "resource_discovery" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  description = "Resource discovery policy for ${module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name} addon"
+  name        = "${module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name}-resource-discovery" # tflint-ignore: aws_iam_policy_invalid_name
+  path        = "/"
+  policy      = data.aws_iam_policy_document.resource_discovery[0].json
+
+  tags = var.irsa_tags
+}
+
+resource "aws_iam_role_policy_attachment" "resource_discovery" {
+  count = local.irsa_policy_enabled ? 1 : 0
+
+  role       = module.addon-irsa[local.addon.name].irsa_iam_role_attributes.name
+  policy_arn = aws_iam_policy.resource_discovery[0].arn
 }

--- a/interruption.tf
+++ b/interruption.tf
@@ -1,5 +1,5 @@
 locals {
-  aws_partition_dns_suffix = data.aws_partition.current[0].dns_suffix
+  aws_partition_dns_suffix = data.aws_partition.this[0].dns_suffix
 }
 
 resource "aws_sqs_queue" "this" {
@@ -25,7 +25,6 @@ data "aws_iam_policy_document" "queue" {
         "sqs.${local.aws_partition_dns_suffix}",
       ]
     }
-
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ locals {
     name = "karpenter-crds"
 
     helm_chart_name       = "karpenter-crd"
-    helm_chart_version    = "1.8.1"
+    helm_chart_version    = "1.8.6"
     helm_repo_url         = local.helm_repo_url
     helm_create_namespace = false # CRDs are cluster-wide resources
 
@@ -28,16 +28,13 @@ locals {
   addon = {
     name = "karpenter"
 
-    helm_chart_version = "1.8.1"
+    helm_chart_version = "1.8.6"
     helm_repo_url      = local.helm_repo_url
     helm_skip_crds     = var.crds_enabled # CRDs are installed by the CRDs module, if enabled
   }
 
   addon_irsa = {
-    (local.addon.name) = {
-      irsa_policy_enabled = local.irsa_policy_enabled
-      irsa_policy         = var.irsa_policy != null ? var.irsa_policy : try(data.aws_iam_policy_document.this[0].json, "")
-    }
+    (local.addon.name) = {}
   }
 
   addon_values = yamlencode({
@@ -66,6 +63,14 @@ data "aws_eks_cluster" "this" {
   name  = var.cluster_name
 }
 
-data "aws_partition" "current" {
+data "aws_partition" "this" {
+  count = var.enabled ? 1 : 0
+}
+
+data "aws_region" "this" {
+  count = var.enabled ? 1 : 0
+}
+
+data "aws_caller_identity" "this" {
   count = var.enabled ? 1 : 0
 }


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

This pull request refactors and enhances the IAM policy and resource management for the Karpenter addon, primarily by splitting a large policy into multiple smaller, purpose-specific policies to comply with AWS managed policy size limits and to align with upstream recommendations. It also updates the Karpenter Helm chart version and makes minor improvements to variable and data source usage.

**IAM Policy Refactoring and Enhancements:**

* Split the monolithic `aws_iam_policy_document` into multiple documents and attached policies (`node_lifecycle`, `iam_integration`, `eks_integration`, `interruption`, `resource_discovery`) to comply with AWS managed policy size limits and to match Karpenter's upstream CloudFormation best practices. Each policy is now attached individually to the IRSA role. [[1]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL2-L18) [[2]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecR342-R413) [[3]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecL405-R518)
* Added new resource ARNs for `capacity-reservation` to the EC2-related IAM policy statements, ensuring Karpenter can interact with capacity reservations as required by the latest upstream policy. [[1]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecR25) [[2]](diffhunk://#diff-2bb47ab35b4fcfacd8f871bd1f4bd594f5d1c2a89c0eb861c0e305175a0ef4ecR68)
* Improved the logic for enabling the IRSA policy (`local.irsa_policy_enabled`) to ensure it is only enabled when all necessary conditions are met, including addon enablement, absence of a custom policy, and IRSA role enablement.

**Helm Chart and Data Source Updates:**

* Updated the Karpenter and Karpenter CRD Helm chart versions from `1.8.1` to `1.8.6` to ensure the latest features and fixes are included. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL16-R16) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL31-R37)
* Refactored data sources for AWS partition, region, and caller identity to use consistent naming and conditional creation based on module enablement. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL69-R74) [[2]](diffhunk://#diff-bcb61aa052b8dbc68986ced4ac22c18c23c22cb7e1c3e6821b4837c46f586b41L2-R2)

**Variable and Local Refactoring:**

* Minor cleanup in `interruption.tf` for local variable usage and formatting.

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

- Checked if policy is up to date with upstream policy
- Checked if default policy can be disabled and external one can be provided
- Checked Karpenter controller after upgrade (logs for errors, run test for scaling)

